### PR TITLE
feat: auto-initialize hinter-core-data/ as git repo at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,8 @@ RUN npm i
 COPY .clinerules/ ./.clinerules/
 COPY ai/ ./ai/
 
-CMD ["code-server", "--auth", "none", "--disable-telemetry", "--bind-addr", "0.0.0.0:8080", "/app"]
+# Copy startup script and make it executable
+COPY startup.sh /app/startup.sh
+RUN chmod +x /app/startup.sh
+
+CMD ["/app/startup.sh"]

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Startup script for hinter-cline container
+# Initializes hinter-core-data/ as a git repository if it hasn't been initialized
+
+HINTER_DATA_DIR="/app/hinter-core-data"
+
+echo "Starting hinter-cline initialization..."
+
+# Check if hinter-core-data directory exists
+if [ -d "$HINTER_DATA_DIR" ]; then
+    echo "Found hinter-core-data directory at $HINTER_DATA_DIR"
+    
+    # Check if it's already a git repository
+    if [ ! -d "$HINTER_DATA_DIR/.git" ]; then
+        echo "Initializing $HINTER_DATA_DIR as a git repository..."
+        cd "$HINTER_DATA_DIR"
+        git init
+        echo "Git repository initialized successfully"
+    else
+        echo "Git repository already exists in $HINTER_DATA_DIR"
+    fi
+    
+    # Create entries directory if it doesn't exist
+    if [ ! -d "$HINTER_DATA_DIR/entries" ]; then
+        echo "Creating entries/ directory..."
+        mkdir -p "$HINTER_DATA_DIR/entries"
+        echo "entries/ directory created"
+    else
+        echo "entries/ directory already exists"
+    fi
+    
+    # Create .gitignore if it doesn't exist
+    if [ ! -f "$HINTER_DATA_DIR/.gitignore" ]; then
+        echo "Creating .gitignore file..."
+        cat > "$HINTER_DATA_DIR/.gitignore" << 'EOF'
+# macOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+*~
+EOF
+        echo ".gitignore file created"
+    else
+        echo ".gitignore file already exists"
+    fi
+    
+    echo "hinter-core-data initialization complete"
+else
+    echo "Warning: hinter-core-data directory not found at $HINTER_DATA_DIR"
+    echo "This may be because the volume mount is not properly configured"
+fi
+
+echo "Starting code-server..."
+exec code-server --auth none --disable-telemetry --bind-addr 0.0.0.0:8080 /app


### PR DESCRIPTION
Fixes #1

## Summary

- Add startup.sh script that runs at container startup
- Initialize hinter-core-data/ as git repo if not already initialized
- Create entries/ directory if missing
- Create .gitignore with .DS_Store and other common files to ignore
- Update Dockerfile to run startup script before code-server

The startup script will now automatically initialize the hinter-core-data/ directory as a git repository when the container starts, making it practical to use VS Code as an interface without manual git setup.

Generated with [Claude Code](https://claude.ai/code)